### PR TITLE
Mseunghwan

### DIFF
--- a/app/src/main/java/com/example/businessreportgenerator/data/domain/AnalystReport.kt
+++ b/app/src/main/java/com/example/businessreportgenerator/data/domain/AnalystReport.kt
@@ -48,7 +48,7 @@ enum class GraphType {
  * 보고서 데이터 모델
  */
 data class AnalystReport(
-    val id: String,
+    val id: Long = 0L,
     val title: String,
     val summary: String,
     val date: Date,

--- a/app/src/main/java/com/example/businessreportgenerator/data/domain/Asset.kt
+++ b/app/src/main/java/com/example/businessreportgenerator/data/domain/Asset.kt
@@ -1,9 +1,7 @@
 package com.example.businessreportgenerator.data.domain
 
-import java.util.UUID
-
 data class Asset(
-    val id: String = UUID.randomUUID().toString(),
+    val id: Long = 0L,
     val name: String,
     val type: AssetType,
     val purchasePrice: Double,

--- a/app/src/main/java/com/example/businessreportgenerator/data/domain/Report.kt
+++ b/app/src/main/java/com/example/businessreportgenerator/data/domain/Report.kt
@@ -3,7 +3,7 @@ package com.example.businessreportgenerator.data.domain
 import java.util.Date
 
 data class Report(
-    val id: String,
+    val id: Long = 0L,
     val title: String,
     val description: String,
     val createdAt: Date,

--- a/app/src/main/java/com/example/businessreportgenerator/data/local/converter/ReportTypeConverter.kt
+++ b/app/src/main/java/com/example/businessreportgenerator/data/local/converter/ReportTypeConverter.kt
@@ -1,0 +1,13 @@
+package com.example.businessreportgenerator.data.local.converter
+
+import androidx.room.TypeConverter
+import com.example.businessreportgenerator.data.domain.ReportType
+
+class ReportTypeConverter {
+
+    @TypeConverter
+    fun fromReportType(type: ReportType): String = type.name   // enum→String
+
+    @TypeConverter
+    fun toReportType(value: String): ReportType = ReportType.valueOf(value) // String→enum
+}

--- a/app/src/main/java/com/example/businessreportgenerator/data/local/dao/ReportDao.kt
+++ b/app/src/main/java/com/example/businessreportgenerator/data/local/dao/ReportDao.kt
@@ -17,4 +17,7 @@ interface ReportDao {
 
     @Query("SELECT * FROM reports")
     fun selectAllReports(): Flow<List<ReportEntity>>
+
+    @Query("SELECT * FROM reports ORDER BY date DESC")
+    fun observeReports(): Flow<List<ReportEntity>>
 }

--- a/app/src/main/java/com/example/businessreportgenerator/data/local/dao/ReportDao.kt
+++ b/app/src/main/java/com/example/businessreportgenerator/data/local/dao/ReportDao.kt
@@ -3,14 +3,15 @@ package com.example.businessreportgenerator.data.local.dao
 import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
+import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.example.businessreportgenerator.data.local.entity.ReportEntity
 import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface ReportDao {
-    @Insert
-    fun insertReport(report: ReportEntity)
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertReport(entity: ReportEntity)
 
     @Delete
     fun deleteReport(report: ReportEntity)

--- a/app/src/main/java/com/example/businessreportgenerator/data/local/entity/AssetEntity.kt
+++ b/app/src/main/java/com/example/businessreportgenerator/data/local/entity/AssetEntity.kt
@@ -4,12 +4,11 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.example.businessreportgenerator.data.domain.Asset
 import com.example.businessreportgenerator.data.domain.AssetType
-import java.util.UUID
 
 @Entity(tableName = "assets")
 data class AssetEntity(
-    @PrimaryKey
-    val id: String = UUID.randomUUID().toString(),
+    @PrimaryKey(autoGenerate = true)
+    val id: Long? = null,
     val name: String,
     val type: AssetType,
     val purchasePrice: Double,
@@ -19,7 +18,7 @@ data class AssetEntity(
     // 도메인 모델로 변환하는 확장 함수
     fun toAsset(): Asset {
         return Asset(
-            id = id,
+            id = id ?: 0L,
             name = name,
             type = type,
             purchasePrice = purchasePrice,

--- a/app/src/main/java/com/example/businessreportgenerator/data/local/entity/ReportEntity.kt
+++ b/app/src/main/java/com/example/businessreportgenerator/data/local/entity/ReportEntity.kt
@@ -3,7 +3,6 @@ package com.example.businessreportgenerator.data.local.entity
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import androidx.room.TypeConverters
-import com.example.businessreportgenerator.data.domain.ReportType
 import com.example.businessreportgenerator.data.local.converter.ReportTypeConverter
 
 @Entity(tableName = "reports")
@@ -15,5 +14,5 @@ data class ReportEntity(
     val content: String,
     val summary: String,
     val date: Long,
-    val type: ReportType
+    val type: String
 )

--- a/app/src/main/java/com/example/businessreportgenerator/data/local/entity/ReportEntity.kt
+++ b/app/src/main/java/com/example/businessreportgenerator/data/local/entity/ReportEntity.kt
@@ -2,13 +2,18 @@ package com.example.businessreportgenerator.data.local.entity
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import androidx.room.TypeConverters
+import com.example.businessreportgenerator.data.domain.ReportType
+import com.example.businessreportgenerator.data.local.converter.ReportTypeConverter
 
 @Entity(tableName = "reports")
+@TypeConverters(ReportTypeConverter::class)
 data class ReportEntity(
     @PrimaryKey(autoGenerate = true)
-    val id: Int = 0,
+    val id: Long? = null,
     val title: String,
     val content: String,
     val summary: String,
-    val date: Long
+    val date: Long,
+    val type: ReportType
 )

--- a/app/src/main/java/com/example/businessreportgenerator/data/local/repository/ReportRepository.kt
+++ b/app/src/main/java/com/example/businessreportgenerator/data/local/repository/ReportRepository.kt
@@ -4,10 +4,9 @@ import com.example.businessreportgenerator.data.local.dao.ReportDao
 import com.example.businessreportgenerator.data.local.entity.ReportEntity
 import kotlinx.coroutines.flow.Flow
 
-class ReportRepository(private val reportDao: ReportDao) : ReportRepositoryInterface {
-    override fun insertReport(report: ReportEntity) = reportDao.insertReport(report)
+class ReportRepository(private val dao: ReportDao) {
 
-    override fun deleteReport(report: ReportEntity) = reportDao.deleteReport(report)
+    fun observeReports(): Flow<List<ReportEntity>> = dao.observeReports()
 
-    override fun getAllReports(): Flow<List<ReportEntity>> = reportDao.selectAllReports()
+    suspend fun insertReport(entity: ReportEntity) = dao.insertReport(entity)
 }

--- a/app/src/main/java/com/example/businessreportgenerator/data/local/repository/ReportRepository.kt
+++ b/app/src/main/java/com/example/businessreportgenerator/data/local/repository/ReportRepository.kt
@@ -8,5 +8,6 @@ class ReportRepository(private val dao: ReportDao) {
 
     fun observeReports(): Flow<List<ReportEntity>> = dao.observeReports()
 
-    suspend fun insertReport(entity: ReportEntity) = dao.insertReport(entity)
+    suspend fun insertReport(entity: ReportEntity) =          // suspend 함수
+        dao.insertReport(entity)
 }

--- a/app/src/main/java/com/example/businessreportgenerator/data/mapper/ReportMapper.kt
+++ b/app/src/main/java/com/example/businessreportgenerator/data/mapper/ReportMapper.kt
@@ -1,0 +1,20 @@
+import com.example.businessreportgenerator.data.domain.Report
+import com.example.businessreportgenerator.data.local.entity.ReportEntity
+import java.util.Date
+
+fun ReportEntity.toDomain() = Report(
+    id          = id ?: 0L,
+    title       = title,
+    description = summary,
+    createdAt   = Date(date),
+    type        = type                                // 그대로 enum
+)
+
+fun Report.toEntity() = ReportEntity(
+    id      = if (id == 0L) null else id,
+    title    = title,
+    content  = description,
+    summary  = description,
+    date     = createdAt.time,
+    type     = type                                   // 그대로 enum
+)

--- a/app/src/main/java/com/example/businessreportgenerator/data/mapper/ReportMapper.kt
+++ b/app/src/main/java/com/example/businessreportgenerator/data/mapper/ReportMapper.kt
@@ -1,20 +1,19 @@
-import com.example.businessreportgenerator.data.domain.Report
+package com.example.businessreportgenerator.data.mapper
+
+import com.example.businessreportgenerator.data.domain.AnalystReport
+import com.example.businessreportgenerator.data.domain.ReportSentiment
 import com.example.businessreportgenerator.data.local.entity.ReportEntity
 import java.util.Date
 
-fun ReportEntity.toDomain() = Report(
-    id          = id ?: 0L,
-    title       = title,
-    description = summary,
-    createdAt   = Date(date),
-    type        = type                                // 그대로 enum
-)
-
-fun Report.toEntity() = ReportEntity(
-    id      = if (id == 0L) null else id,
-    title    = title,
-    content  = description,
-    summary  = description,
-    date     = createdAt.time,
-    type     = type                                   // 그대로 enum
-)
+/** Room Entity → 화면용 AnalystReport */
+fun ReportEntity.toAnalystReport(): AnalystReport =
+    AnalystReport(
+        id              = id ?: 0L,          // Entity id 가 Long? 일 때 null → 0L
+        title           = title,
+        summary         = summary,
+        date            = Date(date),
+        sentiment       = ReportSentiment.NEUTRAL, // 서버에서 값 주면 바꿔주세요
+        category        = type,                    // Entity.type(String) 그대로
+        graphData       = emptyList(),             // 아직 그래프 없음
+        detailedContent = content
+    )

--- a/app/src/main/java/com/example/businessreportgenerator/data/remote/model/ReportDTO.kt
+++ b/app/src/main/java/com/example/businessreportgenerator/data/remote/model/ReportDTO.kt
@@ -1,5 +1,6 @@
 package com.example.businessreportgenerator.data.remote.model
 
+import com.example.businessreportgenerator.data.domain.ReportType
 import com.example.businessreportgenerator.data.local.entity.ReportEntity
 import com.google.gson.annotations.SerializedName
 
@@ -26,12 +27,11 @@ class ReportResponse {
         return "ReportResponse(code=$code, status=$status, message=$message, data=$data)"
     }
 
-    fun toDomain() : ReportEntity {
-        return ReportEntity(
-            title = data?.insight?.substring(0 until 10) ?: "",
-            content = data?.insight ?: "",
-            summary = data?.summary ?: "",
-            date = System.currentTimeMillis()
-        )
-    }
+    fun toDomain(): ReportEntity = ReportEntity(
+        title   = data?.insight?.take(40) ?: "",
+        content = data?.insight ?: "",
+        summary = data?.summary ?: "",
+        date    = System.currentTimeMillis(),
+        type    = ReportType.CUSTOM          // ★ 기본값 넣기 (또는 서버 값 매핑)
+    )
 }

--- a/app/src/main/java/com/example/businessreportgenerator/data/remote/model/ReportDTO.kt
+++ b/app/src/main/java/com/example/businessreportgenerator/data/remote/model/ReportDTO.kt
@@ -32,6 +32,6 @@ class ReportResponse {
         content = data?.insight ?: "",
         summary = data?.summary ?: "",
         date    = System.currentTimeMillis(),
-        type    = ReportType.CUSTOM          // ★ 기본값 넣기 (또는 서버 값 매핑)
+        type    = ReportType.CUSTOM.toString()          // ★ 기본값 넣기 (또는 서버 값 매핑)
     )
 }

--- a/app/src/main/java/com/example/businessreportgenerator/di/ServiceLocator.kt
+++ b/app/src/main/java/com/example/businessreportgenerator/di/ServiceLocator.kt
@@ -1,0 +1,31 @@
+package com.example.businessreportgenerator.di
+
+import android.content.Context
+import androidx.room.Room
+import com.example.businessreportgenerator.data.local.AppDatabase
+import com.example.businessreportgenerator.data.local.repository.ReportRepository
+
+object ServiceLocator {
+
+    // ① DB
+    @Volatile private var database: AppDatabase? = null
+
+    private fun provideDatabase(context: Context): AppDatabase =
+        database ?: synchronized(this) {
+            database ?: Room.databaseBuilder(
+                context.applicationContext,
+                AppDatabase::class.java,
+                "bigpicture.db"
+            ).build().also { database = it }
+        }
+
+    // ② Repository
+    @Volatile private var reportRepo: ReportRepository? = null
+
+    fun provideReportRepository(context: Context): ReportRepository =
+        reportRepo ?: synchronized(this) {
+            reportRepo ?: ReportRepository(
+                provideDatabase(context).reportDao()
+            ).also { reportRepo = it }
+        }
+}

--- a/app/src/main/java/com/example/businessreportgenerator/presentation/features/analyst/AnalystSample.kt
+++ b/app/src/main/java/com/example/businessreportgenerator/presentation/features/analyst/AnalystSample.kt
@@ -11,7 +11,7 @@ import java.util.Date
 object DummyReportData {
     val reports = listOf(
         AnalystReport(
-            id = "1",
+            id = 1,
             title = "2024년 2분기 반도체 시장 전망",
             summary = "반도체 시장의 견조한 수요와 AI 칩 성장으로 인해 긍정적인 전망이 유지되고 있습니다.",
             date = Date(System.currentTimeMillis() - 2 * 24 * 3600 * 1000), // 2일 전
@@ -71,7 +71,7 @@ object DummyReportData {
             """.trimIndent()
         ),
         AnalystReport(
-            id = "2",
+            id = 2,
             title = "원자재 가격 상승과 인플레이션 영향 분석",
             summary = "글로벌 원자재 가격 상승으로 인한 인플레이션 압력이 높아지고 있어 관련 산업에 주의가 필요합니다.",
             date = Date(System.currentTimeMillis() - 5 * 24 * 3600 * 1000), // 5일 전
@@ -132,7 +132,7 @@ object DummyReportData {
             """.trimIndent()
         ),
         AnalystReport(
-            id = "3",
+            id = 3,
             title = "테슬라 1분기 실적 분석 및 전망",
             summary = "테슬라의 1분기 실적이 시장 예상을 하회하며 전기차 시장 경쟁 심화에 따른 우려가 커지고 있습니다.",
             date = Date(System.currentTimeMillis() - 8 * 24 * 3600 * 1000), // 8일 전
@@ -190,7 +190,7 @@ object DummyReportData {
             """.trimIndent()
         ),
         AnalystReport(
-            id = "4",
+            id = 4,
             title = "국내 부동산 시장 동향과 투자 전략",
             summary = "국내 부동산 시장은 금리 인하 기대감으로 인한 관망세가 지속되고 있으며, 지역별 차별화가 심화되고 있습니다.",
             date = Date(System.currentTimeMillis() - 12 * 24 * 3600 * 1000), // 12일 전
@@ -254,7 +254,7 @@ object DummyReportData {
             """.trimIndent()
         ),
         AnalystReport(
-            id = "5",
+            id = 5,
             title = "2024년 2분기 글로벌 경제 전망",
             summary = "글로벌 경제는 완만한 회복세를 보이고 있으나, 각국의 통화정책 변화와 지정학적 리스크에 주의가 필요합니다.",
             date = Date(System.currentTimeMillis() - 15 * 24 * 3600 * 1000), // 15일 전

--- a/app/src/main/java/com/example/businessreportgenerator/presentation/features/analyst/AnalystViewModelFactory.kt
+++ b/app/src/main/java/com/example/businessreportgenerator/presentation/features/analyst/AnalystViewModelFactory.kt
@@ -1,0 +1,14 @@
+package com.example.businessreportgenerator.presentation.features.analyst
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+
+class AnalystViewModelFactory(
+    private val appContext: Context
+) : ViewModelProvider.Factory {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T =
+        AnalystViewmodel(appContext) as T                // ★ Context만 전달
+}

--- a/app/src/main/java/com/example/businessreportgenerator/presentation/features/analyst/AnalystViewmodel.kt
+++ b/app/src/main/java/com/example/businessreportgenerator/presentation/features/analyst/AnalystViewmodel.kt
@@ -13,6 +13,7 @@ import com.example.businessreportgenerator.data.remote.model.ReportRequest
 import com.example.businessreportgenerator.data.remote.model.ReportResponse
 import com.example.businessreportgenerator.data.remote.network.RetrofitClient
 import com.example.businessreportgenerator.di.ServiceLocator
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -109,7 +110,9 @@ class AnalystViewmodel(
             })
     }
 
-    private fun save(entity: ReportEntity) = viewModelScope.launch {
-        repository.insertReport(entity)
-    }
+    private fun save(entity: ReportEntity) {
+        viewModelScope.launch(Dispatchers.IO) {         // ❸
+            repository.insertReport(entity)
+        }
+}
 }

--- a/app/src/main/java/com/example/businessreportgenerator/presentation/features/analyst/AnalystViewmodel.kt
+++ b/app/src/main/java/com/example/businessreportgenerator/presentation/features/analyst/AnalystViewmodel.kt
@@ -1,5 +1,6 @@
 package com.example.businessreportgenerator.presentation.features.analyst
 
+import android.content.Context
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -7,14 +8,16 @@ import com.example.businessreportgenerator.data.domain.AnalystReport
 import com.example.businessreportgenerator.data.domain.ReportSentiment
 import com.example.businessreportgenerator.data.local.entity.ReportEntity
 import com.example.businessreportgenerator.data.local.repository.ReportRepository
+import com.example.businessreportgenerator.data.mapper.toAnalystReport
 import com.example.businessreportgenerator.data.remote.model.ReportRequest
 import com.example.businessreportgenerator.data.remote.model.ReportResponse
 import com.example.businessreportgenerator.data.remote.network.RetrofitClient
-import kotlinx.coroutines.Dispatchers
+import com.example.businessreportgenerator.di.ServiceLocator
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -22,88 +25,91 @@ import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
 
-data class AnalystUiState(
-    val selectedReport: AnalystReport? = null,
-    val selectedCategory: String? = null,
-    val selectedSentiment: ReportSentiment? = null,
-)
+/**
+ * Room → Repository → ViewModel → UI   (DI 프레임워크 없이)
+ */
+class AnalystViewmodel(
+    context: Context                    // Factory 에서 전달
+) : ViewModel() {
 
-data class RemoteState(
-    val reports: List<AnalystReport> = emptyList(),
-    val categories: List<String> = emptyList(),
-    val sentiments: List<ReportSentiment> = emptyList()
-)
+    /* ──────────────────────────────────────────────── *
+     * 1) Repository & DB stream
+     * ──────────────────────────────────────────────── */
+    private val repository: ReportRepository =
+        ServiceLocator.provideReportRepository(context)
 
-class AnalystViewmodel(private val repository: ReportRepository? = null) : ViewModel() {
-    private val _remoteState = MutableStateFlow(RemoteState())
-    private val _uiState = MutableStateFlow(AnalystUiState())
-    val uiState : MutableStateFlow<AnalystUiState> = _uiState
-    val remoteState : MutableStateFlow<RemoteState> = _remoteState
+    /** Room → Domain(AnalystReport) */
+    private val reportsFlow: StateFlow<List<AnalystReport>> =
+        repository.observeReports()
+            .map { list -> list.map { it.toAnalystReport() } }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
-    val filteredReports : StateFlow<List<AnalystReport>> =
-        combine(_remoteState, _uiState) { remote : RemoteState, ui : AnalystUiState ->
-            remote.reports.filter { report ->
-                (ui.selectedCategory == null || report.category == ui.selectedCategory) &&
-                        (ui.selectedSentiment == null || report.sentiment == ui.selectedSentiment)
+    /* ──────────────────────────────────────────────── *
+     * 2) Filter 상태
+     * ──────────────────────────────────────────────── */
+    data class FilterState(
+        val category: String? = null,
+        val sentiment: ReportSentiment? = null
+    )
+    private val _filter = MutableStateFlow(FilterState())
+    val filterState: StateFlow<FilterState> = _filter        // 화면에서 collect 가능
+
+    /* 새 이름 setter */
+    fun setCategory(c: String?)           = _filter.update { it.copy(category = c) }
+    fun setSentiment(s: ReportSentiment?) = _filter.update { it.copy(sentiment = s) }
+
+    /* ──────────────────────────────────────────────── *
+     * 3) UI에 노출할 Flow
+     * ──────────────────────────────────────────────── */
+    val filteredReports: StateFlow<List<AnalystReport>> =
+        combine(reportsFlow, _filter) { list, f ->
+            list.filter {
+                (f.category  == null || it.category  == f.category) &&
+                        (f.sentiment == null || it.sentiment == f.sentiment)
             }
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
-    init {
-        fetchAnalystReports()
-    }
+    /** Chip에 쓸 목록 */
+    val categoriesFlow: StateFlow<List<String>> =
+        reportsFlow
+            .map { list -> list.map { it.category }.distinct() }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+    val sentiments: List<ReportSentiment> = ReportSentiment.entries
 
-    private fun fetchAnalystReports() {
-        viewModelScope.launch {
-            val reports = DummyReportData.reports
-            val sentiments = ReportSentiment.entries
-            _remoteState.value = _remoteState.value.copy(
-                reports = reports,
-                categories = reports.map { it.category }.distinct(),
-                sentiments = sentiments
-            )
-        }
-    }
+    /* ──────────────────────────────────────────────── *
+     * 4) 상세 화면 선택 상태
+     * ──────────────────────────────────────────────── */
+    private val _selectedReport = MutableStateFlow<AnalystReport?>(null)
+    val selectedReport: StateFlow<AnalystReport?> = _selectedReport
+    fun setSelectedReport(r: AnalystReport?) { _selectedReport.value = r }
 
-    fun requestReport(report: ReportRequest) {
-        val call = RetrofitClient.ReportService.createReport(report)
-        call.enqueue(object : Callback<ReportResponse> {
-            override fun onResponse(
-                call: Call<ReportResponse>,
-                response: Response<ReportResponse>
-            ) {
-                Log.d("reportRequest", report.toString())
-                if (response.isSuccessful) {
-                    val reportResponse = response.body()
-                    if (reportResponse != null) {
-                        addReport(reportResponse.toDomain())
-                    }
-                    Log.d("BigPicture", reportResponse.toString())
-                    Log.d("BigPicture", "reportRequest : Success")
-                } else {
-                    Log.d("BigPicture", "reportRequest : invalid body")
+    /* ──────────────────────────────────────────────── *
+     * 5)  옛 화면 코드 호환용 alias
+     * ──────────────────────────────────────────────── */
+    val selectedCategory  get() = _filter.value.category
+    val selectedSentiment get() = _filter.value.sentiment
+    fun setSelectedCategory(c: String?)           = setCategory(c)
+    fun setSelectedSentiment(s: ReportSentiment?) = setSentiment(s)
+
+    /* ──────────────────────────────────────────────── *
+     * 6)  서버 요청 → DB 저장
+     * ──────────────────────────────────────────────── */
+    fun requestReport(req: ReportRequest) {
+        RetrofitClient.ReportService.createReport(req)
+            .enqueue(object : Callback<ReportResponse> {
+                override fun onResponse(
+                    call: Call<ReportResponse>,
+                    response: Response<ReportResponse>
+                ) {
+                    response.body()?.toDomain()?.let { save(it) }
                 }
-            }
-            override fun onFailure(call: Call<ReportResponse>, t: Throwable) {
-                Log.d("BigPicture", "reportRequest : network error")
-            }
-        })
+                override fun onFailure(call: Call<ReportResponse>, t: Throwable) {
+                    Log.e("AnalystVM", "network error", t)
+                }
+            })
     }
 
-    fun addReport(report: ReportEntity) {
-        viewModelScope.launch(Dispatchers.IO) {
-            repository?.insertReport(report)
-        }
-    }
-
-    fun setSelectedReport(report: AnalystReport?) {
-        _uiState.update { it.copy(selectedReport = report) }
-    }
-
-    fun setSelectedCategory(category: String?) {
-        _uiState.update { it.copy(selectedCategory = category) }
-    }
-
-    fun setSelectedSentiment(sentiment: ReportSentiment?) {
-        _uiState.update { it.copy(selectedSentiment = sentiment) }
+    private fun save(entity: ReportEntity) = viewModelScope.launch {
+        repository.insertReport(entity)
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #31 


## 📝 작업 내용
> 
<img width="1512" alt="스크린샷 2025-05-12 오후 5 32 24" src="https://github.com/user-attachments/assets/70542d27-b30f-4d9a-9019-80c1dea364a5" />
 - AnalystScreen의 더미 리포트 데이터를 API 응답값으로 대체
 - Room DB 기반 리포트 목록 갱신 로직 적용 (observeReports → filteredReports)
 - 기존 데이터 클래스(Asset, Report, Stock 등) id 타입 String → Long 으로 수정 및 대응 매핑 수정
 - API 응답과 Room 저장 과정 비동기 처리 (Dispatchers.IO 적용)
 - ViewModel 구조 정리 및 UI 연동 오류 수정

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 


## ⏰ 현재 버그
 - AssetType이 Custom으로 고정된 것 같은데 이후 바꾸면 될 것 같습니다

## ✏ Git Close
> close #31 